### PR TITLE
Set a non-empty description in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pytest-web3-data"
-description = ''
+description = "A pytest plugin to fetch test data from IPFS HTTP gateways during pytest execution."
 readme = "README.md"
 requires-python = ">=3.7"
 license = "MIT"


### PR DESCRIPTION
Somehow, the empty description ends up as `null` in the json obtained from the PyPI API, which trips up the automatic plugin listing of pytest.